### PR TITLE
add article id to article detail route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2624,7 +2624,7 @@
     },
     "compression": {
       "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
+      "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
       "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
       "dev": true,
       "requires": {

--- a/src/Stores/Article.js
+++ b/src/Stores/Article.js
@@ -18,11 +18,11 @@ class ArticleStore {
 
     // Actions
 
-    provideArticle(articleSlug, language) {
+    provideArticle(articleId, language) {
 
         let query = Client.items()
             .type('article')
-            .equalsFilter('elements.url_pattern', articleSlug)
+            .equalsFilter('system.id', articleId)
             .elementsParameter(['title', 'teaser_image', 'post_date', 'body_copy', 'video_host', 'video_id', 'tweet_link', 'theme', 'display_options'])
 
         if (language) {
@@ -33,9 +33,9 @@ class ArticleStore {
             .subscribe(response => {
                 if (!response.isEmpty) {
                     if (language) {
-                        articleDetails[language][articleSlug] = response.items[0];
+                        articleDetails[language][articleId] = response.items[0];
                     } else {
-                        articleDetails[defaultLanguage][articleSlug] = response.items[0];
+                        articleDetails[defaultLanguage][articleId] = response.items[0];
                     }
                     notifyChange();
                 }

--- a/src/Utilities/ContentLinks.js
+++ b/src/Utilities/ContentLinks.js
@@ -2,7 +2,7 @@ export function resolveContentLink(link, language) {
   let resultLink;
   switch (link.type) {
     case "article":
-      resultLink = `/articles/${link.url_slug}`;
+      resultLink = `/articles/${link.itemId}`;
       break;
     case "coffee":
       resultLink = `/coffees/${link.url_slug}`;

--- a/src/components/Article.vue
+++ b/src/components/Article.vue
@@ -42,7 +42,7 @@
         },
         watch: {
             language: function(){
-                ArticleStore.provideArticle(this.$route.params.articleName, this.language);
+                ArticleStore.provideArticle(this.$route.params.articleId, this.language);
                 dateFormat.i18n = dateFormats[this.language] || dateFormats[0];
             }
         },
@@ -51,17 +51,17 @@
                 return dateFormat(value, "dddd, mmmm d, yyyy");
             },
             onChange: function(){
-                this.article = ArticleStore.getArticle(this.$route.params.articleName, this.language);
+                this.article = ArticleStore.getArticle(this.$route.params.articleId, this.language);
             }
         },
         created: function(){
             ArticleStore.addChangeListener(this.onChange);
-            ArticleStore.provideArticle(this.$route.params.articleName, this.language);
+            ArticleStore.provideArticle(this.$route.params.articleId, this.language);
             dateFormat.i18n = dateFormats[this.language] || dateFormats[0];
-            this.article = ArticleStore.getArticle(this.$route.params.articleName, this.language);
+            this.article = ArticleStore.getArticle(this.$route.params.articleId, this.language);
         },
         beforeUpdate: function(){
-            this.article = ArticleStore.getArticle(this.$route.params.articleName, this.language);
+            this.article = ArticleStore.getArticle(this.$route.params.articleId, this.language);
         },
         destroyed: function(){
             ArticleStore.removeChangeListener(this.onChange);

--- a/src/components/Articles.vue
+++ b/src/components/Articles.vue
@@ -46,7 +46,7 @@ export default {
         imageLink: article.teaserImage.value[0].url,
         postDate: this.formatDate(article.postDate.value),
         summary: article.summary.value,
-        link: `/${this.language}/articles/${article.urlPattern.value}`
+        link: `/${this.language}/articles/${article.system.id}`
       }));
     }
   },

--- a/src/components/LatestArticles.vue
+++ b/src/components/LatestArticles.vue
@@ -62,7 +62,7 @@
                     imageLink : article.teaserImage.value[0].url,
                     postDate : this.formatDate(article.postDate.value),
                     summary : article.summary.value,
-                    link : `/${this.language}/articles/${article.urlPattern.value}`,
+                    link : `/${this.language}/articles/${article.system.id}`,
                 }))
             }
         },

--- a/src/main.js
+++ b/src/main.js
@@ -57,7 +57,7 @@ let router = new Router({
             component: Articles,
         },
         {
-            path: "/:lang?/articles/:articleName",
+            path: "/:lang?/articles/:articleId",
             component: Article,
         },
         {


### PR DESCRIPTION
It would be better to wait for #9.

Currently, it is impossible to go to the eng article and then change the language to Spanish culture (URL slug remain the same).

The solution is similar to one in react sample app:
* https://github.com/Kentico/cloud-sample-app-react/commit/850b811313d1c9bddaa9917dc3133bc0a50fefd7
