### PR TITLE
Make configuration page url case insensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ This is a sample website written in JavaScript utilizing the Kentico Cloud Deliv
 
 ### Connecting to your sample project
 
-At the first run of the app, you'll be presented with a configuration page. It will allow you to connect the app to your Kentico Cloud sample project or create a new one. You'll also be able to start a trial and convert to a free plan when the trial expires. 
+At the first run of the app, you'll be presented with a configuration page. It will allow you to connect the app to your Kentico Cloud sample project or create a new one. You'll also be able to start a trial and convert to a free plan when the trial expires.
+
+* If you want to open the configuration page after the project is already connected to the app. Just open url <http://localhost:8080/Admin/Configuration>.
 
 Alternatively, you can connect your project manually as per the chapter below.
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
     <div 
-        v-if="this.$route.path !== projectConfigurationPath" 
+        v-if="this.$route.path.toLowerCase() !== projectConfigurationPath.toLowerCase()" 
         id="app" 
         class="application-content"
     >


### PR DESCRIPTION
### Motivation

When you already select a Kentico Cloud project you want to use with the app and try to go on "/admin/configuration" (lowercase) id had display header menu above the configuration page which is not intended.
![image](https://user-images.githubusercontent.com/9218736/47989822-37ea4500-e0e6-11e8-907a-11c975c19df6.png)

Related pull request
#11 

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [x] Docu has been updated (if applicable)
- [x] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults

### How to test

Try to go to the configuration page after you alrady selected a project that should be used within the app.
Try select shared project + try use already created one (or generate one).