### PR TITLE
Add else statement to article body copy

### DIFF
--- a/src/components/Article.vue
+++ b/src/components/Article.vue
@@ -30,7 +30,7 @@
             <div class="row">
                 <RichTextElement
                     v-if="articleData.bodyCopyElement.getHtml()"
-                    styleClass="article-detail-content"
+                    class="article-detail-content"
                     :element="articleData.bodyCopyElement"
                 />
                 <span

--- a/src/components/Article.vue
+++ b/src/components/Article.vue
@@ -33,7 +33,10 @@
                     styleClass="article-detail-content"
                     :element="articleData.bodyCopyElement"
                 />
-                <span class="article-detail-content">{{ $t('Article.noBodyCopyValue')}}</span>
+                <span
+                    v-else
+                    class="article-detail-content"
+                >{{ $t('Article.noBodyCopyValue')}}</span>
             </div>
         </article>
     </div>


### PR DESCRIPTION
### Motivation

Fixes #29

### Checklist

- [X] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Open an article and if the body copy is filled in, the message "No body copy element filled" should not appear at the end.
